### PR TITLE
add some funcs for setting the name of printers from your code.

### DIFF
--- a/examples/print_demo/print_demo.ino
+++ b/examples/print_demo/print_demo.ino
@@ -14,6 +14,11 @@ void setup() {
   // Hand buffer to printer
   cat.begin(buffer, sizeof(buffer));
 
+  // Set the name of the printer to be searched
+  cat.printNameArray();
+  cat.resetNameArray();
+  cat.addNameArray((char *)"MX09");
+  
   // Every non-zero color is white
   cat.fillScreen(1);
   cat.setTextWrap(true);

--- a/src/CatGFX.cpp
+++ b/src/CatGFX.cpp
@@ -6,11 +6,17 @@ CatPrinter::CatPrinter(uint16_t h):
   SERVICE_UUID("0000AE30-0000-1000-8000-00805F9B34FB"),
   CHAR_UUID_DATA("0000AE01-0000-1000-8000-00805F9B34FB")
 {
-	  strcpy(this->printer_names[0], "GT01");
-	  strcpy(this->printer_names[1], "GB01");
-	  strcpy(this->printer_names[2], "GB02");
-	  strcpy(this->printer_names[3], "MX09");
-	  strcpy(this->printer_names[4], "");
+	if (this->NAME_ARRAY_SIZE >= 5)
+	{
+	  strcpy(this->printerNames[0], "GT01");
+	  strcpy(this->printerNames[1], "GB01");
+	  strcpy(this->printerNames[2], "GB02");
+	  strcpy(this->printerNames[3], "MX09");
+	  for (int i = 4; i < this->NAME_ARRAY_SIZE; i ++)
+		strcpy(this->printerNames[i], "");
+	}
+	else if (this->NAME_ARRAY_SIZE >= 1)
+		strcpy(this->printerNames[0], "");
 }
 
 void CatPrinter::begin(byte *buffer, uint16_t size) {
@@ -123,8 +129,8 @@ void CatPrinter::printBuffer(void) {
 void CatPrinter::onResult(BLEAdvertisedDevice advertisedDevice) {
 	uint8_t i = 0;
 
-	while (i < this->NAME_ARRAY_SIZE && strcmp(this->printer_names[i], "") != 0){
-	  if (strcmp(advertisedDevice.getName().c_str(), this->printer_names[i]) == 0) {
+	while (i < this->NAME_ARRAY_SIZE && strcmp(this->printerNames[i], "") != 0){
+	  if (strcmp(advertisedDevice.getName().c_str(), this->printerNames[i]) == 0) {
 		blePrinterAddress = new BLEAddress(advertisedDevice.getAddress());
 		Serial.print("Found Printer: ");
 		Serial.println(blePrinterAddress->toString().c_str());
@@ -206,7 +212,7 @@ void CatPrinter::fillScreen(uint16_t color) {
 void CatPrinter::resetNameArray(void)
 {
 	for (uint8_t i = 0; i < this->NAME_ARRAY_SIZE; i ++)
-		strcpy(this->printer_names[i], "");
+		strcpy(this->printerNames[i], "");
 }
 
 bool CatPrinter::addNameArray(char *newname)
@@ -217,21 +223,21 @@ bool CatPrinter::addNameArray(char *newname)
 		return (false);
 	while (i < this->NAME_ARRAY_SIZE)
 	{
-		if (strcmp(this->printer_names[i], "") != 0)
+		if (strcmp(this->printerNames[i], "") != 0)
 			i ++;
 		else
 			break ;
 	}
 	if (i >= this->NAME_ARRAY_SIZE - 1)
 		return (false);
-	strcpy(this->printer_names[i], newname);
+	strcpy(this->printerNames[i], newname);
 	return (true);
 }
 
 void CatPrinter::printNameArray(void)
 {
 	for (uint8_t i = 0; i < NAME_ARRAY_SIZE; i ++)
-		Serial.println(this->printer_names[i]);
+		Serial.println(this->printerNames[i]);
 }
 
 

--- a/src/CatGFX.cpp
+++ b/src/CatGFX.cpp
@@ -1,5 +1,18 @@
 #include "CatGFX.h"
 
+CatPrinter::CatPrinter(uint16_t h): 
+  Adafruit_GFX(384, h),
+  WIDTH_BYTE((WIDTH + 7)/8),
+  SERVICE_UUID("0000AE30-0000-1000-8000-00805F9B34FB"),
+  CHAR_UUID_DATA("0000AE01-0000-1000-8000-00805F9B34FB")
+{
+	  strcpy(this->printer_names[0], "GT01");
+	  strcpy(this->printer_names[1], "GB01");
+	  strcpy(this->printer_names[2], "GB02");
+	  strcpy(this->printer_names[3], "MX09");
+	  strcpy(this->printer_names[4], "");
+}
+
 void CatPrinter::begin(byte *buffer, uint16_t size) {
   pixelBuffer = buffer;
   pixelBufferSize = size;
@@ -108,15 +121,19 @@ void CatPrinter::printBuffer(void) {
 }
 
 void CatPrinter::onResult(BLEAdvertisedDevice advertisedDevice) {
-  if (strcmp(advertisedDevice.getName().c_str(), "GT01") == 0 ||
-      strcmp(advertisedDevice.getName().c_str(), "GB01") == 0 ||
-      strcmp(advertisedDevice.getName().c_str(), "GB02") == 0 ||
-      strcmp(advertisedDevice.getName().c_str(), "MX09") == 0 ) {
-    blePrinterAddress = new BLEAddress(advertisedDevice.getAddress());
-    Serial.print("Found Printer: ");
-    Serial.println(blePrinterAddress->toString().c_str());
-    bleScan->stop();
-  }
+	uint8_t i = 0;
+
+	while (i < this->NAME_ARRAY_SIZE && strcmp(this->printer_names[i], "") != 0){
+	  if (strcmp(advertisedDevice.getName().c_str(), this->printer_names[i]) == 0) {
+		blePrinterAddress = new BLEAddress(advertisedDevice.getAddress());
+		Serial.print("Found Printer: ");
+		Serial.println(blePrinterAddress->toString().c_str());
+		bleScan->stop();
+  	  	break ;
+	  }
+	  else
+		i ++;
+   	}
 }
 
 void CatPrinter::sendCmd(const CatPrinter::Cmd cmd, const byte *data, const uint8_t len) {
@@ -185,3 +202,36 @@ void CatPrinter::drawPixel(int16_t x, int16_t y, uint16_t color) {
 void CatPrinter::fillScreen(uint16_t color) {
   fillBuffer((!color ? 0xFF : 0x00));
 }
+
+void CatPrinter::resetNameArray(void)
+{
+	for (uint8_t i = 0; i < this->NAME_ARRAY_SIZE; i ++)
+		strcpy(this->printer_names[i], "");
+}
+
+bool CatPrinter::addNameArray(char *newname)
+{
+	uint8_t i = 0;
+
+	if (strlen(newname) >= NAME_STRING_SIZE)
+		return (false);
+	while (i < this->NAME_ARRAY_SIZE)
+	{
+		if (strcmp(this->printer_names[i], "") != 0)
+			i ++;
+		else
+			break ;
+	}
+	if (i >= this->NAME_ARRAY_SIZE - 1)
+		return (false);
+	strcpy(this->printer_names[i], newname);
+	return (true);
+}
+
+void CatPrinter::printNameArray(void)
+{
+	for (uint8_t i = 0; i < NAME_ARRAY_SIZE; i ++)
+		Serial.println(this->printer_names[i]);
+}
+
+

--- a/src/CatGFX.h
+++ b/src/CatGFX.h
@@ -54,7 +54,7 @@ class CatPrinter: public Adafruit_GFX, public BLEAdvertisedDeviceCallbacks {
 	//Indicates the end of the array with an empty string instead of NULL.
 	const static uint8_t NAME_ARRAY_SIZE = 6;
 	const static uint8_t NAME_STRING_SIZE = 8;
-	char printer_names[NAME_ARRAY_SIZE][NAME_STRING_SIZE];
+	char printerNames[NAME_ARRAY_SIZE][NAME_STRING_SIZE];
 
     const byte LATTICE_START[11] = {0xAA, 0x55, 0x17, 0x38, 0x44, 0x5F, 0x5F, 0x5F, 0x44, 0x38, 0x2C};
     const byte LATTICE_END[11] = {0xAA, 0x55, 0x17, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x17};

--- a/src/CatGFX.h
+++ b/src/CatGFX.h
@@ -15,12 +15,7 @@ class CatPrinter: public Adafruit_GFX, public BLEAdvertisedDeviceCallbacks {
       DRAWING_MODE = 0xBE,
       PRINT_COMPRESSED = 0xBF
     };
-    CatPrinter(uint16_t h): 
-      Adafruit_GFX(384, h),
-      WIDTH_BYTE((WIDTH + 7)/8),
-      SERVICE_UUID("0000AE30-0000-1000-8000-00805F9B34FB"),
-      CHAR_UUID_DATA("0000AE01-0000-1000-8000-00805F9B34FB")
-      {};
+	CatPrinter(uint16_t h);
     ~CatPrinter() {
       delete bleClient;
     }
@@ -38,6 +33,10 @@ class CatPrinter: public Adafruit_GFX, public BLEAdvertisedDeviceCallbacks {
     void fillScreen(uint16_t color) override;
     void startGraphics(void);
     void endGraphics(void);
+	void resetNameArray(void);
+	bool addNameArray(char *newname);
+	void printNameArray(void);
+
   private:
     byte *pixelBuffer = nullptr;
     uint16_t pixelBufferSize = 0;
@@ -51,6 +50,11 @@ class CatPrinter: public Adafruit_GFX, public BLEAdvertisedDeviceCallbacks {
     BLERemoteCharacteristic* pRemoteCharacteristicData = nullptr;
     BLEScan *bleScan = BLEDevice::getScan();
     BLEClient *bleClient = BLEDevice::createClient();;
+
+	//Indicates the end of the array with an empty string instead of NULL.
+	const static uint8_t NAME_ARRAY_SIZE = 6;
+	const static uint8_t NAME_STRING_SIZE = 8;
+	char printer_names[NAME_ARRAY_SIZE][NAME_STRING_SIZE];
 
     const byte LATTICE_START[11] = {0xAA, 0x55, 0x17, 0x38, 0x44, 0x5F, 0x5F, 0x5F, 0x44, 0x38, 0x2C};
     const byte LATTICE_END[11] = {0xAA, 0x55, 0x17, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x17};


### PR DESCRIPTION
# Summary
**Now you can set the names of printers to be scanned from your code, just using member functions.**
<br>

# Added private member of a CatPrinter class: <br>

##	NAME_ARRAY_SIZE = 6;
Setting the max size of char* array of `printer_names`.
## NAME_STRING_SIZE = 8;
Setting the max size of each name.
## printer_names[NAME_ARRAY_SIZE][NAME_STRING_SIZE];
Reserve memory for array of names. 
Indicates the end of the array with an empty string instead of `NULL`.
When you call the constructor of `CatPrinter`, this name array has default value: `GT01`, `GB01`, `GB02`, `MX09`
So you can use both new and old codes without any fixing.
<br>
# Added public member of a CatPrinter class: <br>

## void resetNameArray(void);
Remove all value of `printer_names`.
Replace each value with empty string.

## bool addNameArray(char *newname);
Add `newname` to the printer_names.
If the array is already fulfilled, it returns `false`.

## void printNameArray(void);
Print the values of `printer_names` by `Serial.println`. It maybe useful for debugging.
<br>
# Other fixing
## Moving the implementation of the constructor
I moved the implementation of the constructor from header to .cpp, because the definition of `printer_names` is done below of this function.
## Add these funcs to the print_demo.ino file
Users can easily find a way to set the names of catty printers to be scanned.
<br>
<br>
Thank you for your impressive work!!
<br>
